### PR TITLE
Fixes to CMSO-ISA configurations

### DIFF
--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-20170703/cellmigration-imaging-MIACMEv0.3.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-20170703/cellmigration-imaging-MIACMEv0.3.xml
@@ -1,8 +1,8 @@
 <isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
     <isatab-configuration table-name="cellmigration-imaging-MIACMEv0.3"
         isatab-assay-type="generic_assay" isatab-conversion-target="generic">
-        <measurement term-label="cell migration assay" term-accession="OBI"
-            source-abbreviation="0000366"/>
+        <measurement term-label="cell migration assay" term-accession=""
+            source-abbreviation=""/>
         <technology term-label="microscopy imaging" term-accession="" source-abbreviation=""/>
         <field header="Sample Name" data-type="String" is-file-field="false"
             is-multiple-value="false" is-required="true" is-hidden="false"

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-20170703/cellmigration-imaging-MIACMEv0.3.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-20170703/cellmigration-imaging-MIACMEv0.3.xml
@@ -112,10 +112,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/3d_cell_tracking_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/3d_cell_tracking_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/capillary_chamber_migration_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/capillary_chamber_migration_assay.xml
@@ -104,6 +104,19 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
+        <field header="Derived Data File" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/capillary_tube_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/capillary_tube_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/cell_exclusion_zone_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/cell_exclusion_zone_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/cell_tracking_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/cell_tracking_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/fence_migration_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/fence_migration_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/gelatin_degradation_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/gelatin_degradation_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/in-vitro_wound_healing_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/in-vitro_wound_healing_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/leukocyte_migration_agarose_technique_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/leukocyte_migration_agarose_technique_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/microcarrier_bead_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/microcarrier_bead_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/monodispersed_cell_invasion_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/monodispersed_cell_invasion_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/platypus_invasion_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/platypus_invasion_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/single_cell_motility_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/single_cell_motility_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/spheroid_confrontation_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/spheroid_confrontation_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/spheroid_invasion_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/spheroid_invasion_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/spheroid_migration_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/spheroid_migration_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/transwell_invasion_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/transwell_invasion_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/transwell_migration_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/transwell_migration_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>

--- a/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/vertical_gel_3d_migration_assay.xml
+++ b/v0.3/ISATab-configurations/isaconfig-MIACMEv0.3-multiassay-20170714/vertical_gel_3d_migration_assay.xml
@@ -104,10 +104,17 @@
             <description><![CDATA[Raw Data File]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
+        <protocol-field protocol-type="data transformation"/>
+        <field header="Data Transformation Name" data-type="String" is-file-field="false"
+            is-multiple-value="true" is-required="false" is-hidden="false"
+            is-forced-ontology="false">
+            <description><![CDATA[User-defined name for each data transformation applied]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
         <field header="Derived Data File" data-type="String" is-file-field="false"
             is-multiple-value="true" is-required="false" is-hidden="false"
             is-forced-ontology="false">
-            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study.]]></description>
+            <description><![CDATA[The set of processed images produced by the study OR The set of extracted features produced by the study or the address to a CMSO Track file as a JSON data package .]]></description>
             <default-value><![CDATA[]]></default-value>
         </field>
         <structured-field name="factors"/>


### PR DESCRIPTION
as per commit messages:
adding data transformation protocol and node to assay configuration (to allow use by ISAcreator)
removing reference to OBI in assay table declaration (as terms are not submitted)
--
Note:  sending another PR with corresponding fixes to CMSO ISA datasets



